### PR TITLE
add implementation for redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10098,6 +10098,29 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
+    "react-redux": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.0.tgz",
+      "integrity": "sha512-hyu/PoFK3vZgdLTg9ozbt7WF3GgX5+Yn3pZm5/96/o4UueXA+zj08aiSC9Mfj2WtD1bvpIb3C5yvskzZySzzaw==",
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+          "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
     "react-router": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
@@ -10261,6 +10284,15 @@
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "requires": {
         "minimatch": "3.0.4"
+      }
+    },
+    "redux": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regenerate": {
@@ -11501,6 +11533,11 @@
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "dependencies": {
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-redux": "^7.1.0",
     "react-router-dom": "^5.0.1",
-    "react-scripts": "3.0.1"
+    "react-scripts": "3.0.1",
+    "redux": "^4.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { Provider } from "react-redux";
+import { createStore } from "redux";
 
 import App from "./components/App";
+import reducers from "./reducers";
 
-ReactDOM.render(<App />, document.querySelector("#root"));
+const store = createStore(reducers);
+
+ReactDOM.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+
+  document.querySelector("#root")
+);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,5 @@
+import { combineReducers } from "redux";
+
+export default combineReducers({
+  replaceMe: () => 10
+});


### PR DESCRIPTION
#### What does this PR do?
It adds setup for redux


#### Description of Task to be completed?
- install `redux` and `react-redux` as dependencies
-add `actions` folder to `src` directory
-add `reducers` folder to `src` directory
- implement `redux store` creation in the root `index.js` file


#### How should this be manually tested?
- clone the repo
- run `npm install`
- run `npm start`
- navigate to any of the following routes `http://localhost:3000/`


#### Any background context you want to provide?
N/A


#### What are the relevant pivotal tracker stories? (If applicable)
N/A


#### Screenshots (If applicable)
N/A


#### Questions:
N/A