### PR TITLE
fetch all streams

### DIFF
--- a/db.json
+++ b/db.json
@@ -9,6 +9,17 @@
       "title": "My Second Stream",
       "description": "This is my very second stream",
       "id": 2
+    },
+    {
+      "title": "My third stream",
+      "description": "I love Adesewa so much",
+      "id": 3
+    },
+    {
+      "title": "This is a fourth test stream",
+      "description": "This is my very fourth test stream",
+      "userId": "112859328459144968315",
+      "id": 4
     }
   ]
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -22,8 +22,9 @@ export const signOut = () => {
   };
 };
 
-export const createStream = formValues => async dispatch => {
-  const response = await streams.post("/streams", formValues);
+export const createStream = formValues => async (dispatch, getState) => {
+  const { userId } = getState().auth;
+  const response = await streams.post("/streams", { ...formValues, userId });
   dispatch({
     type: CREATE_STREAM,
     payload: response.data

--- a/src/components/streams/StreamList.js
+++ b/src/components/streams/StreamList.js
@@ -1,11 +1,67 @@
-import React from "react";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { Link } from "react-router-dom";
+import { getStreams } from "../../actions";
 
-const StreamList = () => {
-  return (
-    <div>
-      <h1>StreamList</h1>
-    </div>
-  );
+class StreamList extends Component {
+  componentDidMount() {
+    this.props.getStreams();
+  }
+
+  renderAdminButton(stream) {
+    if (stream.userId === this.props.currentUserId) {
+      return (
+        <div className="right floated content">
+          <button className="ui button primary">Edit</button>
+          <button className="ui button negative">Delete</button>
+        </div>
+      );
+    }
+  }
+
+  renderCreateButton() {
+    if (this.props.isSignedIn) {
+      return (
+        <div style={{ textAlign: "right" }}>
+          <Link to="/streams/new" className="ui button primary">
+            Create Stream
+          </Link>
+        </div>
+      );
+    }
+  }
+  renderList() {
+    return this.props.streams.map(stream => {
+      return (
+        <div className="item" key={stream.id}>
+          {this.renderAdminButton(stream)}
+          <i className="large middle aligned icon camera" />
+          <div className="content">{stream.title}</div>
+          <div className="description">{stream.description}</div>
+        </div>
+      );
+    });
+  }
+  render() {
+    return (
+      <div>
+        <h2>Streams</h2>
+        <div className="ui celled list">{this.renderList()}</div>
+        {this.renderCreateButton()}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => {
+  return {
+    streams: Object.values(state.streams),
+    currentUserId: state.auth.userId,
+    isSignedIn: state.auth.isSignedIn
+  };
 };
 
-export default StreamList;
+export default connect(
+  mapStateToProps,
+  { getStreams }
+)(StreamList);


### PR DESCRIPTION
#### What does this PR do?
it fetches and displays a list of  streams

#### Description of Task to be completed?
- add `edit` and `delete` buttons to streams belonging to logged in user
- add `create stream` button for logged in user to navigate to create stream page


#### How should this be manually tested?
- clone the repo
- run `npm install`
- run `npm start`
- navigate to any of the following routes `http://localhost:3000/streams/new` to create a stream
- navigate to any of the following routes `http://localhost:3000` to see the list of streams


#### Any background context you want to provide?
When a user is signed in and they try to get the list of streams, they should see an `edit` and `delete` button rendered with their stream. Also, authenticated users can see a `Create Stream` button


#### What are the relevant pivotal tracker stories? (If applicable)
N/A


#### Screenshots (If applicable)
N/A


#### Questions:
N/A
