### PR TITLE
add programmatic navigation with stream creation

### DIFF
--- a/db.json
+++ b/db.json
@@ -20,6 +20,12 @@
       "description": "This is my very fourth test stream",
       "userId": "112859328459144968315",
       "id": 4
+    },
+    {
+      "title": "Programmatic Navigation",
+      "description": "This will automatically navigate to the all streams page",
+      "userId": "112859328459144968315",
+      "id": 5
     }
   ]
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -8,6 +8,7 @@ import {
   GET_STREAMS,
   GET_STREAM
 } from "./types";
+import history from "../history";
 
 export const signIn = userId => {
   return {
@@ -29,6 +30,7 @@ export const createStream = formValues => async (dispatch, getState) => {
     type: CREATE_STREAM,
     payload: response.data
   });
+  history.push("/");
 };
 
 export const getStream = id => async dispatch => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,22 +1,24 @@
 import React from "react";
-import { BrowserRouter, Route } from "react-router-dom";
+import { Router, Route } from "react-router-dom";
 import StreamCreate from "./streams/StreamCreate";
 import StreamDelete from "./streams/StreamDelete";
 import StreamEdit from "./streams/StreamEdit";
 import StreamList from "./streams/StreamList";
 import StreamShow from "./streams/StreamShow";
 import Header from "./Header";
+import history from "../history";
+
 const App = () => {
   return (
     <div className="ui container">
-      <BrowserRouter>
+      <Router history={history}>
         <Header />
         <Route path="/" exact component={StreamList} />
         <Route path="/streams/new" exact component={StreamCreate} />
         <Route path="/streams/edit" exact component={StreamEdit} />
         <Route path="/streams/delete" exact component={StreamDelete} />
         <Route path="/streams/show" exact component={StreamShow} />
-      </BrowserRouter>
+      </Router>
     </div>
   );
 };

--- a/src/history.js
+++ b/src/history.js
@@ -1,0 +1,5 @@
+import { createBrowserHistory } from "history";
+
+const history = createBrowserHistory();
+
+export default history;


### PR DESCRIPTION
#### What does this PR do?
it implements programmatic navigation after creating a stream

#### Description of Task to be completed?
- setup history using `createBrowserHistory` from `react-router-dom`


#### How should this be manually tested?
- clone the repo
- run `npm install`
- run `npm start`
- navigate to any of the following routes `http://localhost:3000/streams/new`


#### Any background context you want to provide?
When an authenticated user creates a stream, they should be automatically navigated to the list of streams page


#### What are the relevant pivotal tracker stories? (If applicable)
N/A


#### Screenshots (If applicable)
N/A


#### Questions:
N/A